### PR TITLE
Feature: Support reports on demand (v2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Library
-add_library(heapusage SHARED src/humain.cpp src/hulog.cpp src/humalloc.cpp)
+add_library(heapusage SHARED src/humain.cpp src/hulog.cpp src/humalloc.cpp src/huapi.cpp)
+set_target_properties(heapusage PROPERTIES PUBLIC_HEADER "src/huapi.h")
 target_compile_features(heapusage PRIVATE cxx_variadic_templates)
-install(TARGETS heapusage LIBRARY DESTINATION lib)
+install(TARGETS heapusage
+    LIBRARY DESTINATION lib
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 target_link_libraries(heapusage pthread dl)
 
 # Dependency backward-cpp providing more detailed stacktraces on Linux, when

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ Examples:
     heapusage -t all -m 0 ./ex002
            analyze heap allocations of any size with all tools.
 
+Programs being ran with Heapusage can themselves also request reports from
+Heapusage, while the program is running, by using the `hu_report()` public API
+function. For doing so, they must include the `huapi.h` public header file, link
+with the Heapusage shared library itself and call `hu_report()` when wanted.
+Still, this only works if the program is running through the `heapusage` tool.
+
 Output Format
 =============
 Example output:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ function. For doing so, they must include the `huapi.h` public header file, link
 with the Heapusage shared library itself and call `hu_report()` when wanted.
 Still, this only works if the program is running through the `heapusage` tool.
 
+Alternatively, on Linux, sending a `SIGUSR1` signal to the program being run
+through Heapusage will also produce a Heapusage report on demand.
+
+For both `hu_report()` and `SIGUSR1`, it should be noted that the report will
+reflect the state when they are used, which can e.g. report non-freed memory
+that might be still released before the program exits and, therefore, not
+necessarily constitute a memory leak.
+
 Output Format
 =============
 Example output:

--- a/src/huapi.cpp
+++ b/src/huapi.cpp
@@ -1,0 +1,22 @@
+/*
+ * huapi.cpp
+ *
+ * Copyright (C) 2017-2021 Kristofer Berggren
+ * All rights reserved.
+ *
+ * heapusage is distributed under the BSD 3-Clause license, see LICENSE for details.
+ *
+ */
+
+
+/* ----------- Includes ------------------------------------------ */
+#include "hulog.h"
+
+
+/* ----------- Global Functions ---------------------------------- */
+
+extern "C" void hu_report()
+{
+  log_message("hu_report: Request Log Summary\n");
+  log_summary_safe();
+}

--- a/src/huapi.h
+++ b/src/huapi.h
@@ -1,0 +1,27 @@
+/*
+ * huapi.h
+ *
+ * Copyright (C) 2021 Kristofer Berggren
+ * All rights reserved.
+ *
+ * heapusage is distributed under the BSD 3-Clause license, see LICENSE for details.
+ *
+ */
+
+#ifndef _HUAPI_H_
+#define _HUAPI_H_
+
+
+/* ----------- Global Function Prototypes ------------------------ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void hu_report(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _HUAPI_H_ */

--- a/src/hulog.cpp
+++ b/src/hulog.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdarg.h>
 
 #include <map>
 #include <set>
@@ -385,6 +386,30 @@ void hu_sig_handler(int sig, siginfo_t* si, void* /*ucontext*/)
   exit(EXIT_FAILURE);
 }
 
+void log_message(const char *format, ...)
+{
+  va_list args;
+
+  FILE *f = NULL;
+  if (hu_log_file)
+  {
+    f = fopen(hu_log_file, "a");
+  }
+
+  if (!f)
+  {
+    return;
+  }
+
+  fprintf(f, "==%d== MESSAGE: ", pid);
+
+  va_start(args, format);
+  vfprintf(f, format, args);
+  va_end(args);
+
+  fclose(f);
+}
+
 void log_summary()
 {
   FILE *f = NULL;
@@ -463,6 +488,17 @@ void log_summary()
   fprintf(f, "==%d== \n", pid);
 
   fclose(f);
+}
+
+void log_summary_safe()
+{
+  hu_set_bypass(true);
+  log_enable(0);
+
+  log_summary();
+
+  log_enable(1);
+  hu_set_bypass(false);
 }
 
 void hu_log_remove_freed_allocation(void* ptr)

--- a/src/hulog.cpp
+++ b/src/hulog.cpp
@@ -427,7 +427,7 @@ void log_summary()
   unsigned long long leak_total_blocks = 0;
 
   /* Group results by callstack */
-  static std::map<std::vector<void*>, hu_allocinfo_t> allocations_by_callstack;
+  std::map<std::vector<void*>, hu_allocinfo_t> allocations_by_callstack;
   for (auto it = allocations->begin(); it != allocations->end(); ++it)
   {
     std::vector<void*> callstack;

--- a/src/hulog.h
+++ b/src/hulog.h
@@ -24,5 +24,7 @@ void log_enable(int flag);
 void log_event(int event, void* ptr, size_t size);
 void log_invalid_access(void* ptr);
 void hu_sig_handler(int sig, siginfo_t* si, void* /*ucontext*/);
+void log_message(const char *format, ...);
 void log_summary();
+void log_summary_safe();
 void hu_log_remove_freed_allocation(void* ptr);


### PR DESCRIPTION
The tool currently only produces reports on a clean exit from the analyzed program, which is not always achievable (daemons, programs crashing, etc.). An "on demand" report requested programmatically from within the application itself or from the "outside world" via a signal, has proven quite useful in multiple debugging scenarios.

Commit 217b471c0c2b allows requesting reports via a new API function named `hu_report()`.
Commit b094cf7b7c61 allows requesting reports via `SIGUSR1` Linux signals.
Commit fc85514b640d fixes `log_summary()` so that can be called multiple times while the program is running.

v1 (#12) -> v2:
* Rebase onto latest `master`.