### PR TITLE
build: Allow changing call stack limit using `HU_MAX_CALL_STACK` in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@
 cmake_minimum_required(VERSION 3.0...3.22 FATAL_ERROR)
 project(heapusage VERSION 1.0 LANGUAGES C CXX)
 
+set(HU_MAX_CALL_STACK "20" CACHE STRING
+    "Maximum call stack captured by heapusage, in number of entries (20 by default).")
+
 set(COMMON_FLAGS "-funwind-tables -g -Wall -Wextra -Wpedantic -Wshadow \
                   -Wpointer-arith -Wcast-qual -Wno-missing-braces \
                   -Wswitch-default -Wcast-align -Wunreachable-code \
@@ -28,6 +31,11 @@ set_target_properties(heapusage PROPERTIES PUBLIC_HEADER "src/heapusage.h")
 target_compile_features(heapusage PRIVATE cxx_variadic_templates)
 install(TARGETS heapusage LIBRARY DESTINATION lib PUBLIC_HEADER DESTINATION include)
 target_link_libraries(heapusage pthread dl)
+# Pre-processor defines that can be overriden with CMake variables:
+# - HU_MAX_CALL_STACK for overriding MAX_CALL_STACK.
+if (DEFINED HU_MAX_CALL_STACK)
+  target_compile_definitions(heapusage PRIVATE MAX_CALL_STACK=${HU_MAX_CALL_STACK})
+endif()
 
 # Dependency backward-cpp providing more detailed stacktraces on Linux, when
 # either of the following is present (only ONE needed):

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Note that on-demand reporting will reflect the state when they are used, and
 will thus report memory currently in use that might still be released before
 the program exits, and therefore not necessarily constitute a memory leak.
 
+Heapusage uses a default call stack limit of 20 frames per call stack. It is
+possible to change this value at build time by using the `HU_MAX_CALL_STACK`
+CMake variable.
+
 Technical Details
 =================
 Heapusage intercepts calls to malloc/free/calloc/realloc and logs each memory

--- a/src/hulog.cpp
+++ b/src/hulog.cpp
@@ -37,7 +37,10 @@
 
 
 /* ----------- Defines ------------------------------------------- */
+/* Can be externally overridden. */
+#if !defined(MAX_CALL_STACK)
 #define MAX_CALL_STACK 20   /* Limits the callstack depth to store */
+#endif
 
 
 /* ----------- Types --------------------------------------------- */


### PR DESCRIPTION
There might be cases where the (currently hardcoded) limit of 20 frames per call stack used by Heapusage are not enough e.g. for clearly pinpointing the origin of a memory leak.

This way, allow overriding, at build time, the limit of 20 frames per call stack by using the new `HU_MAX_CALL_STACK` variable from CMake.

Default is kept as 20 for backwards compatibility.