### PR TITLE
backward.hpp: fix for macOS on powerpc

### DIFF
--- a/ext/backward-cpp/backward.hpp
+++ b/ext/backward-cpp/backward.hpp
@@ -4220,6 +4220,8 @@ public:
 #elif defined(__mips__)
     error_addr = reinterpret_cast<void *>(
         reinterpret_cast<struct sigcontext *>(&uctx->uc_mcontext)->sc_pc);
+#elif defined(__APPLE__) && defined(__POWERPC__)
+    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__srr0);
 #elif defined(__ppc__) || defined(__powerpc) || defined(__powerpc__) ||        \
     defined(__POWERPC__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.regs->nip);


### PR DESCRIPTION
Existing code fails to compile, fix it.