### PR TITLE
hulog.cpp: define __STDC_FORMAT_MACROS if not defined

### DIFF
--- a/src/hulog.cpp
+++ b/src/hulog.cpp
@@ -9,6 +9,10 @@
  */
 
 /* ----------- Includes ------------------------------------------ */
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <cxxabi.h>
 #include <dlfcn.h>
 #include <execinfo.h>


### PR DESCRIPTION
Some systems need that prior to including `inttypes.h`:
```
[ 71%] Building CXX object CMakeFiles/heapusage.dir/src/hulog.cpp.o
/opt/x86_64/libexec/gcc10-bootstrap/bin/g++ -DBACKWARD_HAS_BACKTRACE=0 -DBACKWARD_HAS_BACKTRACE_SYMBOL=1 -DBACKWARD_HAS_BFD=0 -DBACKWARD_HAS_DW=0 -DBACKWARD_HAS_DWARF=0 -DBACKWARD_HAS_LIBUNWIND=0 -DBACKWARD_HAS_UNWIND=1 -DMAX_CALL_STACK=20 -Dheapusage_EXPORTS -I/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/ext/backward-cpp -I/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/src -pipe -Os -DNDEBUG -isystem/opt/x86_64/include/LegacySupport -I/opt/x86_64/include -D_GLIBCXX_USE_CXX11_ABI=0 -funwind-tables -g -Wall -Wextra -Wpedantic -Wshadow                   -Wpointer-arith -Wcast-qual -Wno-missing-braces                   -Wswitch-default -Wcast-align -Wunreachable-code                   -Wuninitialized -Wno-stringop-overflow -arch x86_64 -mmacosx-version-min=10.6 -fPIC -std=gnu++11 -MD -MT CMakeFiles/heapusage.dir/src/hulog.cpp.o -MF CMakeFiles/heapusage.dir/src/hulog.cpp.o.d -o CMakeFiles/heapusage.dir/src/hulog.cpp.o -c /opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/src/hulog.cpp
make[2]: Leaving directory `/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/build'
/usr/bin/make  -f ext/backward-cpp/CMakeFiles/backward.dir/build.make ext/backward-cpp/CMakeFiles/backward.dir/build
make[2]: Entering directory `/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/build'
[ 76%] Building CXX object ext/backward-cpp/CMakeFiles/backward.dir/backward.cpp.o
cd /opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/build/ext/backward-cpp && /opt/x86_64/libexec/gcc10-bootstrap/bin/g++ -DBACKWARD_HAS_BACKTRACE=0 -DBACKWARD_HAS_BACKTRACE_SYMBOL=1 -DBACKWARD_HAS_BFD=0 -DBACKWARD_HAS_DW=0 -DBACKWARD_HAS_DWARF=0 -DBACKWARD_HAS_LIBUNWIND=0 -DBACKWARD_HAS_UNWIND=1 -I/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/ext/backward-cpp -pipe -Os -DNDEBUG -isystem/opt/x86_64/include/LegacySupport -I/opt/x86_64/include -D_GLIBCXX_USE_CXX11_ABI=0 -funwind-tables -g -Wall -Wextra -Wpedantic -Wshadow                   -Wpointer-arith -Wcast-qual -Wno-missing-braces                   -Wswitch-default -Wcast-align -Wunreachable-code                   -Wuninitialized -Wno-stringop-overflow -Wall -Wextra -pedantic-errors -g -arch x86_64 -mmacosx-version-min=10.6 -fPIC -std=gnu++11 -MD -MT ext/backward-cpp/CMakeFiles/backward.dir/backward.cpp.o -MF CMakeFiles/backward.dir/backward.cpp.o.d -o CMakeFiles/backward.dir/backward.cpp.o -c /opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/ext/backward-cpp/backward.cpp
[ 80%] Building CXX object CMakeFiles/heapusage.dir/src/humalloc.cpp.o
/opt/x86_64/libexec/gcc10-bootstrap/bin/g++ -DBACKWARD_HAS_BACKTRACE=0 -DBACKWARD_HAS_BACKTRACE_SYMBOL=1 -DBACKWARD_HAS_BFD=0 -DBACKWARD_HAS_DW=0 -DBACKWARD_HAS_DWARF=0 -DBACKWARD_HAS_LIBUNWIND=0 -DBACKWARD_HAS_UNWIND=1 -DMAX_CALL_STACK=20 -Dheapusage_EXPORTS -I/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/ext/backward-cpp -I/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/src -pipe -Os -DNDEBUG -isystem/opt/x86_64/include/LegacySupport -I/opt/x86_64/include -D_GLIBCXX_USE_CXX11_ABI=0 -funwind-tables -g -Wall -Wextra -Wpedantic -Wshadow                   -Wpointer-arith -Wcast-qual -Wno-missing-braces                   -Wswitch-default -Wcast-align -Wunreachable-code                   -Wuninitialized -Wno-stringop-overflow -arch x86_64 -mmacosx-version-min=10.6 -fPIC -std=gnu++11 -MD -MT CMakeFiles/heapusage.dir/src/humalloc.cpp.o -MF CMakeFiles/heapusage.dir/src/humalloc.cpp.o.d -o CMakeFiles/heapusage.dir/src/humalloc.cpp.o -c /opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/src/humalloc.cpp
/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/src/hulog.cpp: In function 'void log_print_callstack(FILE*, int, void* const*)':
/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/src/hulog.cpp:152:39: error: expected ')' before 'PRIxPTR'
  152 |       fprintf(f, "==%d==    at 0x%016" PRIxPTR, pid, (unsigned long) callstack[i]);
      |              ~                        ^~~~~~~~
      |                                       )
/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/src/hulog.cpp:152:37: warning: conversion lacks type at end of format [-Wformat=]
  152 |       fprintf(f, "==%d==    at 0x%016" PRIxPTR, pid, (unsigned long) callstack[i]);
      |                                     ^
/opt/x86_64/var/macports/build/_opt_x86_64_SnowLeopardPorts_devel_heapusage/heapusage/work/heapusage-867461cdb82313be185c918a7305e4b9974975b0/src/hulog.cpp:152:18: warning: too many arguments for format [-Wformat-extra-args]
  152 |       fprintf(f, "==%d==    at 0x%016" PRIxPTR, pid, (unsigned long) callstack[i]);
      |                  ^~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/heapusage.dir/src/hulog.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```