### PR TITLE
hulog.cpp/humalloc.cpp: Use inttypes

### DIFF
--- a/src/hulog.cpp
+++ b/src/hulog.cpp
@@ -316,7 +316,7 @@ void log_event(int event, void* ptr, size_t size)
 
                 log_print_callstack(f, callstack_depth, callstack);
 
-                fprintf(f, "%s Address %p is a block of size %ld free'd at:\n",
+                fprintf(f, "%s Address %p is a block of size %zu free'd at:\n",
                         hu_prefix, ptr, allocation->second.size);
 
                 log_print_callstack(f, allocation->second.free_callstack_depth,
@@ -378,7 +378,7 @@ void hu_sig_handler(int sig, siginfo_t* si, void* /*ucontext*/)
             found = true;
             size_t offset = (char*)ptr - ((char*)allocation->second.ptr + allocation->second.size);
 
-            fprintf(f, "%s Address %p is %ld bytes after a block of size %ld alloc'd at:\n",
+            fprintf(f, "%s Address %p is %zu bytes after a block of size %zu alloc'd at:\n",
                     hu_prefix, ptr, offset, allocation->second.size);
 
             log_print_callstack(f, allocation->second.callstack_depth, allocation->second.callstack);
@@ -397,7 +397,7 @@ void hu_sig_handler(int sig, siginfo_t* si, void* /*ucontext*/)
               found = true;
               size_t offset = (char*)ptr - ((char*)allocation->second.ptr + allocation->second.size);
 
-              fprintf(f, "%s Address %p is %ld bytes after a block of size %ld free'd at:\n",
+              fprintf(f, "%s Address %p is %zu bytes after a block of size %zu free'd at:\n",
                       hu_prefix, ptr, offset, allocation->second.size);
 
               log_print_callstack(f, allocation->second.free_callstack_depth,
@@ -413,7 +413,7 @@ void hu_sig_handler(int sig, siginfo_t* si, void* /*ucontext*/)
               found = true;
               size_t offset = (char*)ptr - ((char*)allocation->second.ptr);
 
-              fprintf(f, "%s Address %p is %ld bytes inside a block of size %ld free'd at:\n",
+              fprintf(f, "%s Address %p is %zu bytes inside a block of size %zu free'd at:\n",
                       hu_prefix, ptr, offset, allocation->second.size);
 
               log_print_callstack(f, allocation->second.free_callstack_depth,

--- a/src/humalloc.cpp
+++ b/src/humalloc.cpp
@@ -11,6 +11,7 @@
 /* ----------- Includes ------------------------------------------ */
 #include <atomic>
 #include <cassert>
+#include <cinttypes>
 #include <cstring>
 #include <iostream>
 #include <fstream>
@@ -103,7 +104,7 @@ static int hu_mprotect(void* addr, size_t len, int prot)
   int rv = mprotect(addr, len, prot);
   if (rv != 0)
   {
-    fprintf(stderr, "heapusage error: mprotect(%p, %ld, %d) failed errno %d\n",
+    fprintf(stderr, "heapusage error: mprotect(%p, %zu, %d) failed errno %d\n",
             addr, len, prot, errno);
 
 #if defined(__linux__)
@@ -117,9 +118,9 @@ static int hu_mprotect(void* addr, size_t len, int prot)
     if (callcount > (max_map_count / 2))
     {
       fprintf(stderr,
-              "max_map_count=%ld mprotect_count=%ld, try increasing max_map_count, ex:\n",
+              "max_map_count=%" PRIu64 " mprotect_count=%" PRIu64 ", try increasing max_map_count, ex:\n",
               max_map_count, callcount);
-      fprintf(stderr, "sudo sh -c \"echo %ld > /proc/sys/vm/max_map_count\"\n",
+      fprintf(stderr, "sudo sh -c \"echo %" PRIu64 " > /proc/sys/vm/max_map_count\"\n",
               (2 * max_map_count));
       exit(1);
     }


### PR DESCRIPTION
Prevent warnings on 386 architecture.

```
/root/a/src/hulog.cpp: In function ‘void log_event(int, void*, size_t)’:
/root/a/src/hulog.cpp:319:64: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
  319 |                 fprintf(f, "%s Address %p is a block of size %ld free'd at:\n",
      |                                                              ~~^
      |                                                                |
      |                                                                long int
      |                                                              %d
  320 |                         hu_prefix, ptr, allocation->second.size);
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~ 
      |                                                            |
      |                                                            size_t {aka unsigned int}
/root/a/src/hulog.cpp: In function ‘void hu_sig_handler(int, siginfo_t*, void*)’:
/root/a/src/hulog.cpp:381:44: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
  381 |             fprintf(f, "%s Address %p is %ld bytes after a block of size %ld alloc'd at:\n",
      |                                          ~~^
      |                                            |
      |                                            long int
      |                                          %d
  382 |                     hu_prefix, ptr, offset, allocation->second.size);
      |                                     ~~~~~~  
      |                                     |
      |                                     size_t {aka unsigned int}
/root/a/src/hulog.cpp:381:76: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 6 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
  381 |             fprintf(f, "%s Address %p is %ld bytes after a block of size %ld alloc'd at:\n",
      |                                                                          ~~^
      |                                                                            |
      |                                                                            long int
      |                                                                          %d
  382 |                     hu_prefix, ptr, offset, allocation->second.size);
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~         
      |                                                                |
      |                                                                size_t {aka unsigned int}
/root/a/src/hulog.cpp:400:46: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
  400 |               fprintf(f, "%s Address %p is %ld bytes after a block of size %ld free'd at:\n",
      |                                            ~~^
      |                                              |
      |                                              long int
      |                                            %d
  401 |                       hu_prefix, ptr, offset, allocation->second.size);
      |                                       ~~~~~~  
      |                                       |
      |                                       size_t {aka unsigned int}
/root/a/src/hulog.cpp:400:78: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 6 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
  400 |               fprintf(f, "%s Address %p is %ld bytes after a block of size %ld free'd at:\n",
      |                                                                            ~~^
      |                                                                              |
      |                                                                              long int
      |                                                                            %d
  401 |                       hu_prefix, ptr, offset, allocation->second.size);
      |                                               ~~~~~~~~~~~~~~~~~~~~~~~         
      |                                                                  |
      |                                                                  size_t {aka unsigned int}
/root/a/src/hulog.cpp:416:46: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
  416 |               fprintf(f, "%s Address %p is %ld bytes inside a block of size %ld free'd at:\n",
      |                                            ~~^
      |                                              |
      |                                              long int
      |                                            %d
  417 |                       hu_prefix, ptr, offset, allocation->second.size);
      |                                       ~~~~~~  
      |                                       |
      |                                       size_t {aka unsigned int}
/root/a/src/hulog.cpp:416:79: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 6 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
  416 |               fprintf(f, "%s Address %p is %ld bytes inside a block of size %ld free'd at:\n",
      |                                                                             ~~^
      |                                                                               |
      |                                                                               long int
      |                                                                             %d
  417 |                       hu_prefix, ptr, offset, allocation->second.size);
      |                                               ~~~~~~~~~~~~~~~~~~~~~~~          
      |                                                                  |
      |                                                                  size_t {aka unsigned int}
/root/a/src/humalloc.cpp: In function ‘int hu_mprotect(void*, size_t, int)’:
/root/a/src/humalloc.cpp:106:54: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
  106 |     fprintf(stderr, "heapusage error: mprotect(%p, %ld, %d) failed errno %d\n",
      |                                                    ~~^
      |                                                      |
      |                                                      long int
      |                                                    %d
  107 |             addr, len, prot, errno);
      |                   ~~~                                 
      |                   |
      |                   size_t {aka unsigned int}
/root/a/src/humalloc.cpp:120:32: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘long long unsigned int’ [-Wformat=]
  120 |               "max_map_count=%ld mprotect_count=%ld, try increasing max_map_count, ex:\n",
      |                              ~~^
      |                                |
      |                                long int
      |                              %lld
  121 |               max_map_count, callcount);
      |               ~~~~~~~~~~~~~     
      |               |
      |               long long unsigned int
/root/a/src/humalloc.cpp:120:51: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘uint64_t’ {aka ‘long long unsigned int’} [-Wformat=]
  120 |               "max_map_count=%ld mprotect_count=%ld, try increasing max_map_count, ex:\n",
      |                                                 ~~^
      |                                                   |
      |                                                   long int
      |                                                 %lld
  121 |               max_map_count, callcount);
      |                              ~~~~~~~~~             
      |                              |
      |                              uint64_t {aka long long unsigned int}
/root/a/src/humalloc.cpp:122:44: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘long long unsigned int’ [-Wformat=]
  122 |       fprintf(stderr, "sudo sh -c \"echo %ld > /proc/sys/vm/max_map_count\"\n",
      |                                          ~~^
      |                                            |
      |                                            long int
      |                                          %lld
  123 |               (2 * max_map_count));
      |               ~~~~~~~~~~~~~~~~~~~           
      |                  |
      |                  long long unsigned int
```